### PR TITLE
[User] 회원 단 건 조회 구현

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -1,0 +1,22 @@
+@env=dev
+
+### 로그인
+POST http://localhost:{{SERVER_PORT}}/api/v1/auth/sign-in
+Content-Type: application/json
+
+{
+  "email": "test@test.com",
+  "password": "test1234!"
+}
+
+> {%
+    client.global.set("at", response.body.data.accessToken);
+    client.global.set("id", response.body.data.id);
+%}
+
+### 회원 단 건 조회(관리자)
+GET http://localhost:{{SERVER_PORT}}/api/v1/users/{{id}}
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{}

--- a/src/main/java/com/want/common/audit/AuditorAwareImpl.java
+++ b/src/main/java/com/want/common/audit/AuditorAwareImpl.java
@@ -1,8 +1,12 @@
 package com.want.common.audit;
 
+import com.want.common.infrastructure.security.CustomUserDetails;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -11,6 +15,19 @@ public class AuditorAwareImpl implements AuditorAware<Long> {
   @NotNull
   @Override
   public Optional<Long> getCurrentAuditor() {
-    return Optional.empty();
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null || !authentication.isAuthenticated() ||
+        authentication instanceof AnonymousAuthenticationToken) {
+      return Optional.of(0L);
+    }
+
+    Object principal = authentication.getPrincipal();
+
+    if (principal instanceof CustomUserDetails userDetails) {
+      return Optional.of(userDetails.id());
+    }
+
+    return Optional.of(0L);
   }
 }

--- a/src/main/java/com/want/user/application/dto/auth/response/GetUserResponse.java
+++ b/src/main/java/com/want/user/application/dto/auth/response/GetUserResponse.java
@@ -10,7 +10,6 @@ import lombok.Builder;
 public record GetUserResponse(
     Long id,
     String email,
-    String password,
     String name,
     String phone,
     String profileImage,
@@ -27,7 +26,6 @@ public record GetUserResponse(
     return GetUserResponse.builder()
         .id(user.getId())
         .email(user.getEmail())
-        .password(user.getPassword())
         .name(user.getName())
         .phone(user.getPhone())
         .profileImage(user.getProfileImage())

--- a/src/main/java/com/want/user/application/dto/auth/response/GetUserResponse.java
+++ b/src/main/java/com/want/user/application/dto/auth/response/GetUserResponse.java
@@ -1,0 +1,44 @@
+package com.want.user.application.dto.auth.response;
+
+import com.want.user.domain.user.Role;
+import com.want.user.domain.user.User;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetUserResponse(
+    Long id,
+    String email,
+    String password,
+    String name,
+    String phone,
+    String profileImage,
+    Role role,
+    LocalDateTime createdAt,
+    Long createdBy,
+    LocalDateTime updatedAt,
+    Long updatedBy,
+    LocalDateTime deletedAt,
+    Long deletedBy
+) {
+
+  public static GetUserResponse from(User user) {
+    return GetUserResponse.builder()
+        .id(user.getId())
+        .email(user.getEmail())
+        .password(user.getPassword())
+        .name(user.getName())
+        .phone(user.getPhone())
+        .profileImage(user.getProfileImage())
+        .role(user.getRole())
+        .createdAt(user.getCreatedAt())
+        .createdBy(user.getCreatedBy())
+        .updatedAt(user.getUpdatedAt())
+        .updatedBy(user.getUpdatedBy())
+        .deletedAt(user.getDeletedAt())
+        .deletedBy(user.getDeletedBy())
+        .build();
+  }
+
+}

--- a/src/main/java/com/want/user/application/service/auth/AuthServiceImpl.java
+++ b/src/main/java/com/want/user/application/service/auth/AuthServiceImpl.java
@@ -11,6 +11,7 @@ import com.want.user.application.dto.auth.response.SignInResult;
 import com.want.user.application.dto.auth.response.SignupResponse;
 import com.want.user.domain.auth.AuthErrorCode;
 import com.want.user.domain.repository.UserRepository;
+import com.want.user.domain.user.Role;
 import com.want.user.domain.user.User;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -76,6 +77,7 @@ public class AuthServiceImpl implements AuthService {
         .name(request.name())
         .phone(request.phone())
         .profileImage(request.profileImage())
+        .role(Role.ROLE_ADMIN) // TODO: 편의를 위한 ADMIN 자동 권한 부여
         .build();
 
     userRepository.save(buildUser);

--- a/src/main/java/com/want/user/application/service/user/UserService.java
+++ b/src/main/java/com/want/user/application/service/user/UserService.java
@@ -1,4 +1,9 @@
 package com.want.user.application.service.user;
 
+import com.want.user.application.dto.auth.response.GetUserResponse;
+
 public interface UserService {
+
+
+  GetUserResponse getUser(Long id);
 }

--- a/src/main/java/com/want/user/application/service/user/UserServiceImpl.java
+++ b/src/main/java/com/want/user/application/service/user/UserServiceImpl.java
@@ -1,7 +1,30 @@
 package com.want.user.application.service.user;
 
+import com.want.common.exception.CustomException;
+import com.want.user.application.dto.auth.response.GetUserResponse;
+import com.want.user.domain.repository.UserRepository;
+import com.want.user.domain.user.User;
+import com.want.user.domain.user.UserErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@RequiredArgsConstructor
 @Service
 public class UserServiceImpl implements UserService {
+
+  private final UserRepository userRepository;
+
+  private User findUserById(Long id) {
+    return userRepository.findUserById(id)
+        .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND_BY_ID));
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public GetUserResponse getUser(Long id) {
+    User userById = findUserById(id);
+
+    return GetUserResponse.from(userById);
+  }
 }

--- a/src/main/java/com/want/user/domain/user/UserErrorCode.java
+++ b/src/main/java/com/want/user/domain/user/UserErrorCode.java
@@ -1,0 +1,60 @@
+package com.want.user.domain.user;
+
+import com.want.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@RequiredArgsConstructor
+@Getter
+public enum UserErrorCode implements ErrorCode {
+
+  // ────────────── [회원 조회 관련] ──────────────
+  USER_NOT_FOUND_BY_ID(HttpStatus.NOT_FOUND.value(), "회원 ID를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  USER_NOT_FOUND_BY_PHONE(HttpStatus.NOT_FOUND.value(), "회원 휴대전화번호를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  USER_NOT_FOUND_BY_EMAIL(HttpStatus.NOT_FOUND.value(), "회원 이메일을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  USER_GET_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "해당 회원 정보를 조회할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  USER_ROLE_NOT_VALID(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 회원 권한입니다.", HttpStatus.BAD_REQUEST),
+
+  // ────────────── [회원 가입 관련] ──────────────
+  USER_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), "이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
+  USER_ALREADY_SIGNED_UP(HttpStatus.CONFLICT.value(), "이미 가입된 회원입니다.", HttpStatus.CONFLICT),
+  DUPLICATE_PHONE(HttpStatus.CONFLICT.value(), "휴대전화번호: 이미 존재하는 휴대전화번호입니다.", HttpStatus.CONFLICT),
+  DUPLICATE_EMAIL(HttpStatus.CONFLICT.value(), "이메일: 이미 존재하는 이메일입니다.", HttpStatus.CONFLICT),
+  USER_SIGNUP_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "회원가입에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  FAILED_VERIFY_EMAIL(HttpStatus.BAD_REQUEST.value(), "이메일: 이메일 인증에 실패했습니다.", HttpStatus.BAD_REQUEST),
+
+
+  // ────────────── [회원 정보 수정 관련] ──────────────
+  USER_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "회원 정보 수정에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  USER_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "회원 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  INVALID_PATCH_EMAIL(HttpStatus.FORBIDDEN.value(), "자신의 이메일만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+  INVALID_PATCH_USER(HttpStatus.FORBIDDEN.value(), "자신의 정보만 수정할 수 있습니다.", HttpStatus.FORBIDDEN),
+  INVALID_PATCH_PASSWORD(HttpStatus.UNAUTHORIZED.value(), "비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+  DUPLICATE_PATCH_PASSWORD(HttpStatus.BAD_REQUEST.value(), "이전 비밀번호와 동일합니다.", HttpStatus.BAD_REQUEST),
+  INVALID_USER_NAME(HttpStatus.BAD_REQUEST.value(), "이름이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_USER_ROLE(HttpStatus.BAD_REQUEST.value(), "권한이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+
+  // ────────────── [로그인 관련] ──────────────
+  INVALID_LOGIN(HttpStatus.BAD_REQUEST.value(), "아이디 또는 비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+
+  // ────────────── [토큰 관련] ──────────────
+  TOKEN_EXPIRED(HttpStatus.BAD_REQUEST.value(), "해당 토큰이 만료되었습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_BEARER_TOKEN(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 JWT 토큰입니다.", HttpStatus.BAD_REQUEST),
+  REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "리프레시 토큰을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  MALFORMED_TOKEN(HttpStatus.BAD_REQUEST.value(), "JWT 형식이 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+  TAMPERED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "JWT 서명이 위조되었거나 무결성이 손상되었습니다.", HttpStatus.UNAUTHORIZED),
+  TOKEN_TOO_EARLY(HttpStatus.BAD_REQUEST.value(), "JWT 활성화 시간이 아직 되지 않았습니다.", HttpStatus.BAD_REQUEST),
+  MISSING_USER_ID_IN_TOKEN(HttpStatus.BAD_REQUEST.value(), "토큰에 사용자 ID가 없습니다.", HttpStatus.BAD_REQUEST),
+  MISSING_JWT_ID(HttpStatus.BAD_REQUEST.value(), "토큰에 JWT ID가 없습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_JWT_SUBJECT(HttpStatus.BAD_REQUEST.value(), "JWT Subject가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  INVALID_JWT_TTL(HttpStatus.BAD_REQUEST.value(), "JWT TTL이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
+  TOKEN_ALREADY_USED(HttpStatus.FORBIDDEN.value(), "이미 사용된 토큰입니다.", HttpStatus.FORBIDDEN);
+
+
+  private final Integer code;
+  private final String message;
+  private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/want/user/domain/user/UserSuccessCode.java
+++ b/src/main/java/com/want/user/domain/user/UserSuccessCode.java
@@ -24,7 +24,7 @@ public enum UserSuccessCode implements SuccessCode {
   USER_PATCH_ROLE_SUCCESS(0, "회원 권한 수정에 성공했습니다.", OK),
   USER_DELETE_BY_ID_SUCCESS(0, "회원 삭제에 성공했습니다.", OK),
 
-  // ────────────── [회원가입/로그인 관련] ──────────────
+  // ────────────── [회원가입/로그인/로그아웃 관련] ──────────────
   USER_SIGNUP_SUCCESS(0, "회원가입이 성공적으로 완료되었습니다.", CREATED),
   USER_LOGIN_SUCCESS(0, "로그인이 성공적으로 완료되었습니다.", OK),
   USER_LOGOUT_SUCCESS(0, "로그아웃이 성공적으로 완료되었습니다.", OK),
@@ -33,11 +33,9 @@ public enum UserSuccessCode implements SuccessCode {
   SEND_CODE_SUCCESS(0, "이메일 인증 코드 전송에 성공했습니다.", OK),
   VERIFY_CODE_SUCCESS(0, "이메일 인증 코드가 일치합니다.", OK),
   EMAIL_AVAILABLE(0, "사용 가능한 이메일입니다.", OK),
-  EMAIL_DUPLICATE(0, "이미 사용 중인 이메일입니다.", OK),
 
-  // ────────────── [휴대전화번호 관련] ──────────────
+  // ────────────── [휴대전화번호 인증 관련] ──────────────
   PHONE_AVAILABLE(0, "사용 가능한 휴대전화번호입니다.", OK),
-  PHONE_DUPLICATE(0, "이미 사용 중인 휴대전화번호입니다.", OK),
 
   // ────────────── [JWT 토큰 관련] ──────────────
   USER_TOKEN_GENERATION_SUCCESS(0, "토큰이 성공적으로 발급되었습니다.", OK),

--- a/src/main/java/com/want/user/domain/user/UserSuccessCode.java
+++ b/src/main/java/com/want/user/domain/user/UserSuccessCode.java
@@ -1,0 +1,49 @@
+package com.want.user.domain.user;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+import com.want.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum UserSuccessCode implements SuccessCode {
+
+  // ────────────── [회원 조회 관련] ──────────────
+  USER_GET_SUCCESS(0, "회원 조회에 성공했습니다.", OK),
+  USERS_GET_SUCCESS(0, "회원 목록 조회에 성공했습니다.", OK),
+
+  // ────────────── [회원 수정/삭제 관련] ──────────────
+  USER_UPDATE_SUCCESS(0, "회원 정보 수정에 성공했습니다.", OK),
+  USER_EMAIL_UPDATE_SUCCESS(0, "회원 이메일 수정에 성공했습니다.", OK),
+  USER_PATCH_PASSWORD_SUCCESS(0, "회원 비밀번호 수정에 성공했습니다.", OK),
+  USER_PATCH_ROLE_SUCCESS(0, "회원 권한 수정에 성공했습니다.", OK),
+  USER_DELETE_BY_ID_SUCCESS(0, "회원 삭제에 성공했습니다.", OK),
+
+  // ────────────── [회원가입/로그인 관련] ──────────────
+  USER_SIGNUP_SUCCESS(0, "회원가입이 성공적으로 완료되었습니다.", CREATED),
+  USER_LOGIN_SUCCESS(0, "로그인이 성공적으로 완료되었습니다.", OK),
+  USER_LOGOUT_SUCCESS(0, "로그아웃이 성공적으로 완료되었습니다.", OK),
+
+  // ────────────── [이메일 인증 관련] ──────────────
+  SEND_CODE_SUCCESS(0, "이메일 인증 코드 전송에 성공했습니다.", OK),
+  VERIFY_CODE_SUCCESS(0, "이메일 인증 코드가 일치합니다.", OK),
+  EMAIL_AVAILABLE(0, "사용 가능한 이메일입니다.", OK),
+  EMAIL_DUPLICATE(0, "이미 사용 중인 이메일입니다.", OK),
+
+  // ────────────── [휴대전화번호 관련] ──────────────
+  PHONE_AVAILABLE(0, "사용 가능한 휴대전화번호입니다.", OK),
+  PHONE_DUPLICATE(0, "이미 사용 중인 휴대전화번호입니다.", OK),
+
+  // ────────────── [JWT 토큰 관련] ──────────────
+  USER_TOKEN_GENERATION_SUCCESS(0, "토큰이 성공적으로 발급되었습니다.", OK),
+  USER_TOKEN_VALIDATION_SUCCESS(0, "토큰이 유효합니다.", OK);
+
+  private final Integer code;
+  private final String message;
+  private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/want/user/presentation/UserController.java
+++ b/src/main/java/com/want/user/presentation/UserController.java
@@ -1,4 +1,41 @@
 package com.want.user.presentation;
 
+import com.want.common.response.ApiResponse;
+import com.want.user.application.dto.auth.response.GetUserResponse;
+import com.want.user.application.service.user.UserService;
+import com.want.user.domain.user.UserSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@RestController
 public class UserController {
+
+  private final UserService userService;
+
+  @PreAuthorize("hasAnyRole('ADMIN')")
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<GetUserResponse>> getUser(
+      @PathVariable Long id
+  ) {
+    GetUserResponse response = userService.getUser(id);
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(
+            new ApiResponse<>(
+                UserSuccessCode.USER_GET_SUCCESS.getCode(),
+                UserSuccessCode.USER_GET_SUCCESS.getMessage(),
+                response
+            )
+        );
+  }
+
 }


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.
- 회원 단 건 조회 (관리자용)

## 🔍 관련 이슈
> 예: Closes #123
Closes #30

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 관리자 권한이 있는 사용자가 특정 사용자의 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  - 사용자 상세 정보 조회 시 응답에 표준화된 성공 코드와 메시지가 포함됩니다.
  - 사용자 정보를 반환하는 새로운 응답 객체가 도입되었습니다.
  - 사용자 조회 시 존재하지 않는 경우에 대한 예외 처리가 추가되었습니다.
  - 사용자 인증 및 조회를 위한 HTTP 요청 예시 파일이 추가되었습니다.

- **개선 사항**
  - 사용자 관련 성공 및 에러 코드가 표준화되어 응답에 일관성이 향상되었습니다.
  - 회원 가입 시 기본적으로 관리자 역할이 부여됩니다.
  - 인증된 사용자의 ID를 정확히 추적하여 감사(Audit) 정보에 반영하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->