### PR TITLE
[ProductPolicy] 상품정책 단 건 조회 및 수정

### DIFF
--- a/http/productPolicy.http
+++ b/http/productPolicy.http
@@ -53,7 +53,7 @@ Authorization: Bearer {{at}}
     client.global.set("companyId", response.body.data.id);
 %}
 
-### 상품 등록
+### 상품정책 등록
 POST http://localhost:{{SERVER_PORT}}/api/v1/products/policies
 Content-Type: application/json
 Authorization: Bearer {{at}}
@@ -68,4 +68,35 @@ Authorization: Bearer {{at}}
   "endedAt": "2025-06-20T16:05:30.96040",
   "isActive": false,
   "minPurchaseAmount": 0
+}
+
+> {%
+    client.global.set("id", response.body.data.id);
+%}
+
+### 상품정책 단 건 조회
+GET http://localhost:{{SERVER_PORT}}/api/v1/products/policies/{{id}}
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{}
+
+> {%
+    client.global.set("id", response.body.data.id);
+%}
+
+### 상품정책 수정
+PATCH http://localhost:{{SERVER_PORT}}/api/v1/products/policies/{{id}}
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+  "newName": "수정된 상품정책 이름11",
+  "newDescription": "수정된 상품정책 내용",
+  "newDiscountType": "REGULAR",
+  "newValue": 0,
+  "newStartedAt": "2025-06-11T16:05:30.96040",
+  "newEndedAt": "2025-06-20T16:05:30.96040",
+  "newIsActive": true,
+  "newMinPurchaseAmount": 0
 }

--- a/src/main/java/com/want/product/application/productPolicy/dto/request/UpdateProductPolicyRequest.java
+++ b/src/main/java/com/want/product/application/productPolicy/dto/request/UpdateProductPolicyRequest.java
@@ -1,0 +1,41 @@
+package com.want.product.application.productPolicy.dto.request;
+
+import com.want.product.domain.entity.productPolicy.DiscountType;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public record UpdateProductPolicyRequest(
+    @NotBlank(message = "정책 이름은 필수입니다.")
+    @Size(max = 100, message = "정책 이름은 100자 이내여야 합니다.")
+    String newName,
+
+    @Size(max = 255, message = "설명은 255자 이내여야 합니다.")
+    String newDescription,
+
+    @NotNull(message = "할인 유형은 필수입니다.")
+    DiscountType newDiscountType,
+
+    @NotNull(message = "할인 값은 필수입니다.")
+    @Min(value = 0, message = "할인 값은 0 이상이어야 합니다.")
+    @Max(value = 100, message = "할인 값은 100 이하이어야 합니다.")
+    Integer newValue,
+
+    @NotNull(message = "시작일시는 필수입니다.")
+    @FutureOrPresent(message = "시작일시는 현재 또는 미래여야 합니다.")
+    LocalDateTime newStartedAt,
+
+    @NotNull(message = "종료일시는 필수입니다.")
+    @Future(message = "종료일시는 미래여야 합니다.")
+    LocalDateTime newEndedAt,
+
+    boolean newIsActive,
+
+    @Min(value = 0, message = "최소 구매 금액은 0 이상이어야 합니다.")
+    Integer newMinPurchaseAmount) {
+}

--- a/src/main/java/com/want/product/application/productPolicy/dto/response/GetProductPolicyResponse.java
+++ b/src/main/java/com/want/product/application/productPolicy/dto/response/GetProductPolicyResponse.java
@@ -1,0 +1,102 @@
+package com.want.product.application.productPolicy.dto.response;
+
+import com.want.company.domain.entity.Company;
+import com.want.product.domain.entity.category.Category;
+import com.want.product.domain.entity.product.Product;
+import com.want.product.domain.entity.product.SaleStatus;
+import com.want.product.domain.entity.productPolicy.DiscountType;
+import com.want.product.domain.entity.productPolicy.ProductPolicy;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetProductPolicyResponse(
+    UUID id,
+    String name,
+    String description,
+    DiscountType discountType,
+    Integer value,
+    LocalDateTime startedAt,
+    LocalDateTime endedAt,
+    boolean isActive,
+    Integer minPurchaseAmount,
+    AssignCompany assignCompany,
+    LocalDateTime createdAt,
+    Long createdBy,
+    LocalDateTime updatedAt,
+    Long updatedBy,
+    LocalDateTime deletedAt,
+    Long deletedBy,
+    List<ApplyProducts> applyProducts
+) {
+  public static GetProductPolicyResponse from(ProductPolicy byId) {
+    return GetProductPolicyResponse.builder()
+        .id(byId.getId())
+        .name(byId.getName())
+        .description(byId.getDescription())
+        .discountType(byId.getDiscountType())
+        .value(byId.getValue())
+        .startedAt(byId.getStartedAt())
+        .endedAt(byId.getEndedAt())
+        .isActive(byId.getIsActive())
+        .minPurchaseAmount(byId.getMinPurchaseAmount())
+        .createdAt(byId.getCreatedAt())
+        .createdBy(byId.getCreatedBy())
+        .updatedAt(byId.getUpdatedAt())
+        .updatedBy(byId.getUpdatedBy())
+        .deletedAt(byId.getDeletedAt())
+        .deletedBy(byId.getDeletedBy())
+        .assignCompany(AssignCompany.from(byId.getCompany()))
+        .applyProducts(ApplyProducts.from(byId.getProducts()))
+        .build();
+  }
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private record AssignCompany(
+      UUID id,
+      String name
+  ) {
+
+    private static AssignCompany from(Company company) {
+      return AssignCompany.builder()
+          .id(company.getId())
+          .name(company.getName())
+          .build();
+    }
+  }
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private record ApplyProducts(
+      UUID id,
+      Category category,
+      Company company,
+      ProductPolicy productPolicy,
+      String name,
+      Integer price,
+      Integer quantity,
+      String thumbnail,
+      SaleStatus saleStatus,
+      String description
+  ) {
+    private static List<ApplyProducts> from(List<Product> products) {
+      return products.stream()
+          .map(product -> ApplyProducts.builder()
+              .id(product.getId())
+              .category(product.getCategory())
+              .company(product.getCompany())
+              .productPolicy(product.getProductPolicy())
+              .name(product.getName())
+              .price(product.getPrice())
+              .quantity(product.getQuantity())
+              .thumbnail(product.getThumbnail())
+              .saleStatus(product.getSaleStatus())
+              .description(product.getDescription())
+              .build())
+          .toList();
+    }
+
+  }
+}

--- a/src/main/java/com/want/product/application/productPolicy/dto/response/GetProductPolicyResponse.java
+++ b/src/main/java/com/want/product/application/productPolicy/dto/response/GetProductPolicyResponse.java
@@ -1,7 +1,6 @@
 package com.want.product.application.productPolicy.dto.response;
 
 import com.want.company.domain.entity.Company;
-import com.want.product.domain.entity.category.Category;
 import com.want.product.domain.entity.product.Product;
 import com.want.product.domain.entity.product.SaleStatus;
 import com.want.product.domain.entity.productPolicy.DiscountType;
@@ -61,6 +60,10 @@ public record GetProductPolicyResponse(
   ) {
 
     private static AssignCompany from(Company company) {
+      if (company == null) {
+        return null;
+      }
+
       return AssignCompany.builder()
           .id(company.getId())
           .name(company.getName())
@@ -71,23 +74,21 @@ public record GetProductPolicyResponse(
   @Builder(access = AccessLevel.PRIVATE)
   private record ApplyProducts(
       UUID id,
-      Category category,
-      Company company,
-      ProductPolicy productPolicy,
       String name,
       Integer price,
       Integer quantity,
       String thumbnail,
       SaleStatus saleStatus,
-      String description
+      String description,
+      UUID companyId,
+      UUID categoryId
   ) {
     private static List<ApplyProducts> from(List<Product> products) {
       return products.stream()
           .map(product -> ApplyProducts.builder()
               .id(product.getId())
-              .category(product.getCategory())
-              .company(product.getCompany())
-              .productPolicy(product.getProductPolicy())
+              .categoryId(product.getCategory().getId())
+              .companyId(product.getCompany().getId())
               .name(product.getName())
               .price(product.getPrice())
               .quantity(product.getQuantity())

--- a/src/main/java/com/want/product/application/productPolicy/dto/response/UpdateProductPolicyResponse.java
+++ b/src/main/java/com/want/product/application/productPolicy/dto/response/UpdateProductPolicyResponse.java
@@ -1,6 +1,5 @@
 package com.want.product.application.productPolicy.dto.response;
 
-import com.want.company.domain.entity.Company;
 import com.want.product.domain.entity.productPolicy.DiscountType;
 import com.want.product.domain.entity.productPolicy.ProductPolicy;
 import java.time.LocalDateTime;
@@ -9,7 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = AccessLevel.PRIVATE)
-public record CreateProductPolicyResponse(
+public record UpdateProductPolicyResponse(
     UUID id,
     String name,
     String description,
@@ -19,12 +18,16 @@ public record CreateProductPolicyResponse(
     LocalDateTime endedAt,
     boolean isActive,
     Integer minPurchaseAmount,
-    AssignCompany assignCompany
-    ) {
-  public static CreateProductPolicyResponse from(ProductPolicy productPolicy) {
-    return CreateProductPolicyResponse.builder()
+    LocalDateTime createdAt,
+    Long createdBy,
+    LocalDateTime updatedAt,
+    Long updatedBy,
+    LocalDateTime deletedAt,
+    Long deletedBy
+) {
+  public static UpdateProductPolicyResponse from(ProductPolicy productPolicy) {
+    return UpdateProductPolicyResponse.builder()
         .id(productPolicy.getId())
-        .assignCompany(AssignCompany.from(productPolicy.getCompany()))
         .name(productPolicy.getName())
         .description(productPolicy.getDescription())
         .discountType(productPolicy.getDiscountType())
@@ -33,22 +36,12 @@ public record CreateProductPolicyResponse(
         .endedAt(productPolicy.getEndedAt())
         .isActive(productPolicy.getIsActive())
         .minPurchaseAmount(productPolicy.getMinPurchaseAmount())
+        .createdAt(productPolicy.getCreatedAt())
+        .createdBy(productPolicy.getCreatedBy())
+        .updatedAt(productPolicy.getUpdatedAt())
+        .updatedBy(productPolicy.getUpdatedBy())
+        .deletedAt(productPolicy.getDeletedAt())
+        .deletedBy(productPolicy.getDeletedBy())
         .build();
   }
-
-  @Builder(access = AccessLevel.PRIVATE)
-  private record AssignCompany(
-      UUID id,
-      String name
-  ) {
-
-    private static AssignCompany from(Company company) {
-      return AssignCompany.builder()
-          .id(company.getId())
-          .name(company.getName())
-          .build();
-    }
-  }
-
-
 }

--- a/src/main/java/com/want/product/application/productPolicy/service/ProductPolicyService.java
+++ b/src/main/java/com/want/product/application/productPolicy/service/ProductPolicyService.java
@@ -2,8 +2,17 @@ package com.want.product.application.productPolicy.service;
 
 import com.want.common.infrastructure.security.CustomUserDetails;
 import com.want.product.application.productPolicy.dto.request.CreateProductPolicyRequest;
+import com.want.product.application.productPolicy.dto.request.UpdateProductPolicyRequest;
 import com.want.product.application.productPolicy.dto.response.CreateProductPolicyResponse;
+import com.want.product.application.productPolicy.dto.response.GetProductPolicyResponse;
+import com.want.product.application.productPolicy.dto.response.UpdateProductPolicyResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
 
 public interface ProductPolicyService {
   CreateProductPolicyResponse createProductPolicy(CustomUserDetails userDetails, CreateProductPolicyRequest request);
+
+  GetProductPolicyResponse getProductPolicy(UUID id);
+
+  UpdateProductPolicyResponse updateProductPolicy(CustomUserDetails userDetails, UpdateProductPolicyRequest request, UUID id);
 }

--- a/src/main/java/com/want/product/application/productPolicy/service/ProductPolicyServiceImpl.java
+++ b/src/main/java/com/want/product/application/productPolicy/service/ProductPolicyServiceImpl.java
@@ -5,11 +5,15 @@ import com.want.common.infrastructure.security.CustomUserDetails;
 import com.want.company.domain.entity.Company;
 import com.want.company.domain.repository.CompanyRepository;
 import com.want.product.application.productPolicy.dto.request.CreateProductPolicyRequest;
+import com.want.product.application.productPolicy.dto.request.UpdateProductPolicyRequest;
 import com.want.product.application.productPolicy.dto.response.CreateProductPolicyResponse;
+import com.want.product.application.productPolicy.dto.response.GetProductPolicyResponse;
+import com.want.product.application.productPolicy.dto.response.UpdateProductPolicyResponse;
 import com.want.product.domain.entity.productPolicy.ProductPolicy;
 import com.want.product.domain.entity.productPolicy.ProductPolicyErrorCode;
 import com.want.product.domain.repository.ProductPolicyRepository;
 import com.want.product.domain.repository.ProductRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,8 +30,13 @@ public class ProductPolicyServiceImpl implements ProductPolicyService {
     if (productPolicyRepository.existsFindProductPolicyByName(name)) {
       throw new CustomException(ProductPolicyErrorCode.POLICY_NAME_DUPLICATE);
     }
-
   }
+
+  private ProductPolicy findById(UUID id) {
+    return productPolicyRepository.findById(id)
+        .orElseThrow(() -> new CustomException(ProductPolicyErrorCode.POLICY_NAME_NOT_FOUND));
+  }
+
 
   @Transactional
   @Override
@@ -55,5 +64,36 @@ public class ProductPolicyServiceImpl implements ProductPolicyService {
     ProductPolicy saveProductPolicy = productPolicyRepository.save(productPolicy);
 
     return CreateProductPolicyResponse.from(saveProductPolicy);
+  }
+
+  @Transactional(readOnly = true)
+  @Override
+  public GetProductPolicyResponse getProductPolicy(UUID id) {
+    ProductPolicy byId = findById(id);
+
+    return GetProductPolicyResponse.from(byId);
+  }
+
+  @Transactional
+  @Override
+  public UpdateProductPolicyResponse updateProductPolicy(
+      CustomUserDetails userDetails,
+      UpdateProductPolicyRequest request,
+      UUID id) {
+    existsFindProductPolicyByName(request.newName());
+    ProductPolicy byId = findById(id);
+
+    byId.updateName(request.newName());
+    byId.updateDescription(request.newDescription());
+    byId.updateDiscountType(request.newDiscountType());
+    byId.updateValue(request.newValue());
+    byId.updateStartedAt(request.newStartedAt());
+    byId.updateEndedAt(request.newEndedAt());
+    byId.updateIsActive(request.newIsActive());
+    byId.updateMinPurchaseAmount(request.newMinPurchaseAmount());
+
+    ProductPolicy saveProductPolicy = productPolicyRepository.save(byId);
+
+    return UpdateProductPolicyResponse.from(saveProductPolicy);
   }
 }

--- a/src/main/java/com/want/product/application/productPolicy/service/ProductPolicyServiceImpl.java
+++ b/src/main/java/com/want/product/application/productPolicy/service/ProductPolicyServiceImpl.java
@@ -26,15 +26,15 @@ public class ProductPolicyServiceImpl implements ProductPolicyService {
   private final CompanyRepository companyRepository;
   private final ProductRepository productRepository;
 
-  private void existsFindProductPolicyByName(String name) {
-    if (productPolicyRepository.existsFindProductPolicyByName(name)) {
+  private void existsFindProductPolicyByName(String newName) {
+    if (productPolicyRepository.existsFindProductPolicyByName(newName)) {
       throw new CustomException(ProductPolicyErrorCode.POLICY_NAME_DUPLICATE);
     }
   }
 
   private ProductPolicy findById(UUID id) {
     return productPolicyRepository.findById(id)
-        .orElseThrow(() -> new CustomException(ProductPolicyErrorCode.POLICY_NAME_NOT_FOUND));
+        .orElseThrow(() -> new CustomException(ProductPolicyErrorCode.POLICY_ID_NOT_FOUND));
   }
 
 

--- a/src/main/java/com/want/product/domain/entity/productPolicy/DiscountType.java
+++ b/src/main/java/com/want/product/domain/entity/productPolicy/DiscountType.java
@@ -1,14 +1,38 @@
 package com.want.product.domain.entity.productPolicy;
 
+import com.want.common.exception.CustomException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum DiscountType {
-  REGULAR("할인 없음"),
-  FIXED("정액 할인"),
-  PERCENTAGE("정률 할인");
+  REGULAR("할인 없음") {
+    @Override
+    public void validateValue(int value) {
+      if (value != 0) {
+        throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_BLANK);
+      }
+    }
+  },
+  FIXED("정액 할인") {
+    @Override
+    public void validateValue(int value) {
+      if (value < 0) {
+        throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_INVALID);
+      }
+    }
+  },
+  PERCENTAGE("정률 할인") {
+    @Override
+    public void validateValue(int value) {
+      if (value < 0 || value > 100) {
+        throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_INVALID);
+      }
+    }
+  };
 
   private final String description;
+
+  public abstract void validateValue(int value);
 }

--- a/src/main/java/com/want/product/domain/entity/productPolicy/DiscountType.java
+++ b/src/main/java/com/want/product/domain/entity/productPolicy/DiscountType.java
@@ -9,7 +9,10 @@ import lombok.RequiredArgsConstructor;
 public enum DiscountType {
   REGULAR("할인 없음") {
     @Override
-    public void validateValue(int value) {
+    public void validateValue(Integer value) {
+      if (value == null) {
+        throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_BLANK);
+      }
       if (value != 0) {
         throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_BLANK);
       }
@@ -17,7 +20,10 @@ public enum DiscountType {
   },
   FIXED("정액 할인") {
     @Override
-    public void validateValue(int value) {
+    public void validateValue(Integer value) {
+      if (value == null) {
+        throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_BLANK);
+      }
       if (value < 0) {
         throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_INVALID);
       }
@@ -25,7 +31,10 @@ public enum DiscountType {
   },
   PERCENTAGE("정률 할인") {
     @Override
-    public void validateValue(int value) {
+    public void validateValue(Integer value) {
+      if (value == null) {
+        throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_BLANK);
+      }
       if (value < 0 || value > 100) {
         throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_INVALID);
       }
@@ -34,5 +43,5 @@ public enum DiscountType {
 
   private final String description;
 
-  public abstract void validateValue(int value);
+  public abstract void validateValue(Integer value);
 }

--- a/src/main/java/com/want/product/domain/entity/productPolicy/ProductPolicy.java
+++ b/src/main/java/com/want/product/domain/entity/productPolicy/ProductPolicy.java
@@ -1,6 +1,7 @@
 package com.want.product.domain.entity.productPolicy;
 
 import com.want.common.audit.BaseEntity;
+import com.want.common.exception.CustomException;
 import com.want.company.domain.entity.Company;
 import com.want.product.domain.entity.product.Product;
 import jakarta.persistence.Column;
@@ -82,6 +83,76 @@ public class ProductPolicy extends BaseEntity {
     this.company = company;
   }
 
+  public void updateName(String name) {
+    if (name == null || name.isEmpty()) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_NAME_BLANK);
+    }
+    this.name = name;
+  }
 
+  public void updateDescription(String description) {
+    if (description == null || description.isEmpty()) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_DESCRIPTION_BLANK);
+    }
+    this.description = description;
+  }
 
+  public void updateDiscountType(DiscountType discountType) {
+    this.discountType = discountType;
+  }
+
+  public void updateValue(Integer value) {
+    if (value == null) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_BLANK);
+    }
+
+    if (value < 0) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_NEGATIVE);
+    }
+
+    if (value > 100) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_INVALID);
+    }
+
+    this.value = value;
+  }
+
+  public void updateStartedAt(LocalDateTime startedAt) {
+    if (startedAt == null) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_STARTED_AT_BLANK);
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+
+    if (startedAt.isBefore(now)) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_START_DATE_IN_PAST);
+    }
+    this.startedAt = startedAt;
+  }
+
+  public void updateEndedAt(LocalDateTime endedAt) {
+    if (endedAt == null) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_ENDED_AT_BLANK);
+    }
+
+    if (endedAt.isBefore(startedAt)) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_DATE_INVALID);
+    }
+
+    this.endedAt = endedAt;
+  }
+
+  public void updateIsActive(Boolean isActive) {
+    this.isActive = isActive;
+  }
+
+  public void updateMinPurchaseAmount(Integer minPurchaseAmount) {
+    if (minPurchaseAmount == null) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_MIN_PURCHASE_AMOUNT_BLANK);
+    }
+    if (minPurchaseAmount < 0) {
+      throw new CustomException(ProductPolicyErrorCode.POLICY_MIN_PURCHASE_AMOUNT_NEGATIVE);
+    }
+    this.minPurchaseAmount = minPurchaseAmount;
+  }
 }

--- a/src/main/java/com/want/product/domain/entity/productPolicy/ProductPolicy.java
+++ b/src/main/java/com/want/product/domain/entity/productPolicy/ProductPolicy.java
@@ -105,15 +105,7 @@ public class ProductPolicy extends BaseEntity {
     if (value == null) {
       throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_BLANK);
     }
-
-    if (value < 0) {
-      throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_NEGATIVE);
-    }
-
-    if (value > 100) {
-      throw new CustomException(ProductPolicyErrorCode.POLICY_VALUE_INVALID);
-    }
-
+    this.discountType.validateValue(value);
     this.value = value;
   }
 

--- a/src/main/java/com/want/product/domain/entity/productPolicy/ProductPolicyErrorCode.java
+++ b/src/main/java/com/want/product/domain/entity/productPolicy/ProductPolicyErrorCode.java
@@ -9,20 +9,40 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ProductPolicyErrorCode implements ErrorCode {
 
-  // ────────────── [상품 정책 조회 관련] ──────────────
+  // ────────────── [상품 정책 조회] ──────────────
   POLICY_ID_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 ID의 상품 정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   POLICY_NAME_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 이름의 상품 정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
-  // ────────────── [상품 정책 등록 관련] ──────────────
+  // ────────────── [상품 정책 등록] ──────────────
   POLICY_NAME_DUPLICATE(HttpStatus.CONFLICT.value(), "이미 존재하는 상품 정책 이름입니다.", HttpStatus.CONFLICT),
-  POLICY_INVALID_CONDITION(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 정책 조건입니다.", HttpStatus.BAD_REQUEST),
   POLICY_APPLY_TARGET_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "정책이 적용될 대상을 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
 
-  // ────────────── [상품 정책 수정/삭제 관련] ──────────────
-  POLICY_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "상품 정책 수정에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-  POLICY_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "상품 정책 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  // ───── [필드 유효성: 이름, 설명, 값] ─────
+  POLICY_NAME_BLANK(HttpStatus.BAD_REQUEST.value(), "상품 정책 이름은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POLICY_DESCRIPTION_BLANK(HttpStatus.BAD_REQUEST.value(), "상품 정책 설명은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POLICY_VALUE_BLANK(HttpStatus.BAD_REQUEST.value(), "상품 정책 값은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POLICY_VALUE_NEGATIVE(HttpStatus.BAD_REQUEST.value(), "상품 정책 값은 음수일 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POLICY_VALUE_INVALID(HttpStatus.BAD_REQUEST.value(), "상품 정책 값은 0 이상 100 이하의 숫자만 가능합니다.", HttpStatus.BAD_REQUEST),
+  POLICY_MIN_PURCHASE_INVALID(HttpStatus.BAD_REQUEST.value(), "최소 구매 금액은 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+  POLICY_MIN_PURCHASE_AMOUNT_BLANK(HttpStatus.BAD_REQUEST.value(), "최소 구매 금액은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POLICY_MIN_PURCHASE_AMOUNT_NEGATIVE(HttpStatus.BAD_REQUEST.value(), "최소 구매 금액은 0 이상이어야 합니다.", HttpStatus.BAD_REQUEST),
+
+  // ───── [시간 유효성 검사] ─────
+  POLICY_STARTED_AT_BLANK(HttpStatus.BAD_REQUEST.value(), "상품 정책 시작일자는 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POLICY_ENDED_AT_BLANK(HttpStatus.BAD_REQUEST.value(), "상품 정책 종료일자는 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST),
+  POLICY_DATE_INVALID(HttpStatus.BAD_REQUEST.value(), "종료일은 시작일보다 이후여야 합니다.", HttpStatus.BAD_REQUEST),
+  POLICY_START_DATE_IN_PAST(HttpStatus.BAD_REQUEST.value(), "시작일은 현재 시간보다 이후여야 합니다.", HttpStatus.BAD_REQUEST),
+  POLICY_PERIOD_OVERLAP(HttpStatus.CONFLICT.value(), "동일한 회사에 대해 중복된 기간의 정책이 존재합니다.", HttpStatus.CONFLICT),
+
+
+  // ───── [상태 및 논리 검사] ─────
   POLICY_ALREADY_APPLIED(HttpStatus.BAD_REQUEST.value(), "이미 적용 중인 정책은 수정 또는 삭제할 수 없습니다.", HttpStatus.BAD_REQUEST),
-  POLICY_NAME_BLANK(HttpStatus.BAD_REQUEST.value(), "상품 정책 이름은 비어 있을 수 없습니다.", HttpStatus.BAD_REQUEST);
+  POLICY_INVALID_CONDITION(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 정책 조건입니다.", HttpStatus.BAD_REQUEST),
+  POLICY_INACTIVE(HttpStatus.BAD_REQUEST.value(), "비활성화된 정책은 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+  // ───── [수정/삭제 실패] ─────
+  POLICY_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "상품 정책 수정에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+  POLICY_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "상품 정책 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
   private final Integer code;
   private final String message;

--- a/src/main/java/com/want/product/domain/repository/ProductPolicyRepository.java
+++ b/src/main/java/com/want/product/domain/repository/ProductPolicyRepository.java
@@ -1,10 +1,14 @@
 package com.want.product.domain.repository;
 
 import com.want.product.domain.entity.productPolicy.ProductPolicy;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface ProductPolicyRepository {
 
   boolean existsFindProductPolicyByName(String name);
 
   ProductPolicy save(ProductPolicy productPolicy);
+
+  Optional<ProductPolicy> findById(UUID id);
 }

--- a/src/main/java/com/want/product/presentation/ProductPolicyController.java
+++ b/src/main/java/com/want/product/presentation/ProductPolicyController.java
@@ -54,7 +54,7 @@ public class ProductPolicyController {
       @PathVariable UUID id) {
     GetProductPolicyResponse response = productPolicyService.getProductPolicy(id);
     return ResponseEntity
-        .status(HttpStatus.CREATED)
+        .status(HttpStatus.OK)
         .body(new ApiResponse<>(
                 ProductPolicySuccessCode.POLICY_FETCHED.getCode(),
                 ProductPolicySuccessCode.POLICY_FETCHED.getMessage(),
@@ -72,7 +72,7 @@ public class ProductPolicyController {
       @PathVariable UUID id) {
     UpdateProductPolicyResponse response = productPolicyService.updateProductPolicy(userDetails, request, id);
     return ResponseEntity
-        .status(HttpStatus.CREATED)
+        .status(HttpStatus.OK)
         .body(new ApiResponse<>(
                 ProductPolicySuccessCode.POLICY_UPDATED.getCode(),
                 ProductPolicySuccessCode.POLICY_UPDATED.getMessage(),

--- a/src/main/java/com/want/product/presentation/ProductPolicyController.java
+++ b/src/main/java/com/want/product/presentation/ProductPolicyController.java
@@ -3,15 +3,22 @@ package com.want.product.presentation;
 import com.want.common.infrastructure.security.CustomUserDetails;
 import com.want.common.response.ApiResponse;
 import com.want.product.application.productPolicy.dto.request.CreateProductPolicyRequest;
+import com.want.product.application.productPolicy.dto.request.UpdateProductPolicyRequest;
 import com.want.product.application.productPolicy.dto.response.CreateProductPolicyResponse;
+import com.want.product.application.productPolicy.dto.response.GetProductPolicyResponse;
+import com.want.product.application.productPolicy.dto.response.UpdateProductPolicyResponse;
 import com.want.product.application.productPolicy.service.ProductPolicyService;
 import com.want.product.domain.entity.productPolicy.ProductPolicySuccessCode;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,4 +46,41 @@ public class ProductPolicyController {
             )
         );
   }
+
+
+  @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'OWNER')")
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<GetProductPolicyResponse>> getProductPolicy(
+      @PathVariable UUID id) {
+    GetProductPolicyResponse response = productPolicyService.getProductPolicy(id);
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(new ApiResponse<>(
+                ProductPolicySuccessCode.POLICY_FETCHED.getCode(),
+                ProductPolicySuccessCode.POLICY_FETCHED.getMessage(),
+                response
+            )
+        );
+  }
+
+
+  @PreAuthorize("hasAnyRole('ADMIN', 'MANAGER', 'OWNER')")
+  @PatchMapping("/{id}")
+  public ResponseEntity<ApiResponse<UpdateProductPolicyResponse>> updateProductPolicy(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody @Valid UpdateProductPolicyRequest request,
+      @PathVariable UUID id) {
+    UpdateProductPolicyResponse response = productPolicyService.updateProductPolicy(userDetails, request, id);
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(new ApiResponse<>(
+                ProductPolicySuccessCode.POLICY_UPDATED.getCode(),
+                ProductPolicySuccessCode.POLICY_UPDATED.getMessage(),
+                response
+            )
+        );
+  }
+
+
+
 }


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.
- 상품정책 단 건 조회
- 상품정책 수정

## 🔍 관련 이슈
> 예: Closes #123
Closes #53
Closes #52 

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 상품정책 단건 조회 및 수정 기능이 추가되었습니다. 이제 상품정책을 ID로 조회하거나, 기존 상품정책의 정보를 수정할 수 있습니다.

- **버그 수정**
    - 상품정책 관련 입력값에 대한 유효성 검증 및 오류 코드가 세분화되어 잘못된 입력 시 더 명확한 안내가 제공됩니다.
    - 할인 유형별 값 검증 로직이 추가되어 정책 값의 정확성이 강화되었습니다.

- **문서화**
    - 상품정책 등록/조회/수정에 대한 HTTP 요청 예시가 문서에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->